### PR TITLE
review

### DIFF
--- a/app/src/main/java/com/thahira/example/jokesmvvmapp/di/KoinModule.kt
+++ b/app/src/main/java/com/thahira/example/jokesmvvmapp/di/KoinModule.kt
@@ -37,8 +37,8 @@ val networkModule = module{
     fun provideNetworkApi(okHttpClient: OkHttpClient, moshi: Moshi) =
         Retrofit.Builder()
             .baseUrl(JokeApi.BASE_URL)
-            .addConverterFactory(MoshiConverterFactory.create())
-            .client(OkHttpClient())
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .client(okHttpClient)
             .build()
             .create(JokeApi::class.java)
 


### PR DESCRIPTION
When using moshi, you need to add the kotlinJasonAdapter to your moshi converter object, you were doing it, but you did not pass the object to the retrofit object.

The same goes for the okhttp object, you do not need to create the new object instead you pass that one by providing it when needed